### PR TITLE
헤로쿠에 배포하기 -  DB 변경 (ClearDB -> JawsDB)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -33,7 +33,7 @@ spring:
 spring:
   config.activate.on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
 
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always


### PR DESCRIPTION
cleardb 의 기본 mysql 버전이 `5.6` 으로
너무 낮기 때문에 대안으로 jawsdb 를 찾아냈습니다.
기본 mysql 버전 `8.0`
이를 이용해 환경변수를 다시 잡았습니다.